### PR TITLE
Some minor bugs I encountered

### DIFF
--- a/src/main/scala/org/splink/cpipe/CPipe.scala
+++ b/src/main/scala/org/splink/cpipe/CPipe.scala
@@ -27,10 +27,10 @@ object CPipe {
           case "import2" =>
             new Importer2().process(session, config)
           case "export" =>
-              new Exporter().process(session, config)
+              new Exporter().process(session, exportConfig(config))
           case "export2" =>
             if (session.getCluster.getMetadata.getPartitioner == "org.apache.cassandra.dht.Murmur3Partitioner") {
-              new Exporter2().process(session, config)
+              new Exporter2().process(session, exportConfig(config))
             } else {
               Output.log("mode 'export2' requires the cluster to use 'Murmur3Partitioner'")
             }
@@ -63,6 +63,16 @@ object CPipe {
     conf.settings.consistencyLevel,
     conf.settings.fetchSize,
     conf.flags.useCompression)
+
+
+  def exportConfig(config: Config): Config = {
+    if (config.settings.threads != 1) {
+      Output.log("Export is limited to 1 thread")
+      config.copy(settings = config.settings.copy(threads = 1))
+    } else {
+      config
+    }
+  }
 
 
   object ElapsedSecondFormat {

--- a/src/main/scala/org/splink/cpipe/JsonColumnParser.scala
+++ b/src/main/scala/org/splink/cpipe/JsonColumnParser.scala
@@ -13,7 +13,15 @@ object JsonColumnParser {
 
   case class Column(name: String, value: Object, typ: DataType)
 
-  private val dateFormat = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  // SimpleDateFormat is not thread safe
+  private val tlDateFormat = new ThreadLocal[java.text.SimpleDateFormat]
+
+  private def dateFormat = {
+    if (tlDateFormat.get() == null) {
+      tlDateFormat.set(new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+    }
+    tlDateFormat.get()
+  }
 
   def column2Json(column: Column) = {
       val value = column.value


### PR DESCRIPTION
Did some minor fixes:

#### Limit export threads to 1
As your output is printed to system.out, writing with multiple threads simultaneously might produce distorted output.

#### Adding parsing logic for null and NaN
I encountered a situation where the data driver would send Double.NaN so I added a case for that. I did the same for null.

#### Adding import logic for null 
There was no null support for the import either, so I added that

#### Make SimpleDateFormat thread safe
Reusing SimpleDateFormat by multiple threads produces parsing errors. I added a fix to create one copy for each thread. This should be more performant dan making it synchronized.